### PR TITLE
Fix language switch

### DIFF
--- a/resources/views/templates/translation.blade.php
+++ b/resources/views/templates/translation.blade.php
@@ -15,7 +15,7 @@
 				    {{ strtoupper($translation) }} <span class="caret"></span>
 				  </button>
 				  <ul class="dropdown-menu">@foreach ($languages as $key=>$value)
-				    <li><a href="{{ route("{$route}show", [$model->$foreign_key, $key]) }}">{{ strtoupper($key) }}</a></li>
+				    <li><a href="{{ route("{$route}edit", [$model->$foreign_key, $key]) }}">{{ strtoupper($key) }}</a></li>
 					@endforeach</ul>
 				</div>
 				@endif


### PR DESCRIPTION
This template is used by the `TranslationController->edit()`, because the language switch points to `show` it will render `TranslationController->show()` instead of `edit()`.