### PR TITLE
Throw an exception with a more helpfull message

### DIFF
--- a/src/Traits/CanBeSecured.php
+++ b/src/Traits/CanBeSecured.php
@@ -17,7 +17,7 @@ trait CanBeSecured
     protected function checkRole() : void
     {
         if (!isset($this->authorizedRoles)) {
-            abort(500, 'You must define $this->authorizedRoles in all Administration controllers');
+            throw new \Exception('You must define $this->authorizedRoles in controller ' . get_class($this));
         }
 
         $authorized = false;


### PR DESCRIPTION
An exception will cause an abort, so the outcome for the user is the same. But an exception will be reported / logged. And now the message points to the right class, so it's easy to fix.